### PR TITLE
added USERAGENT curl option

### DIFF
--- a/OAuth2Client.php
+++ b/OAuth2Client.php
@@ -106,7 +106,8 @@ class OAuth2 {
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_URL, $url);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-		if ($header){
+		curl_setopt($curl, CURLOPT_USERAGENT, 'OAuth2 Client (https://github.com/kasperrt/OAuth2-Client)');
+        if ($header){
 			curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
 		}
 		if ($extended) {

--- a/OAuth2Client.php
+++ b/OAuth2Client.php
@@ -107,7 +107,7 @@ class OAuth2 {
 		curl_setopt($curl, CURLOPT_URL, $url);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($curl, CURLOPT_USERAGENT, 'OAuth2 Client (https://github.com/kasperrt/OAuth2-Client)');
-        if ($header){
+        	if ($header){
 			curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
 		}
 		if ($extended) {


### PR DESCRIPTION
It's possible that PHP's curl does not send a (valid) user-agent, but [services like Github](https://developer.github.com/v3/#user-agent-required) require that you send one, so lets just send one all the time.